### PR TITLE
Fix LaTeX template link

### DIFF
--- a/call.html
+++ b/call.html
@@ -215,7 +215,7 @@
             </p>
             <p>
               All submissions should be formatted in the VGTC conference paper style. Suitable templates, in LaTeX and Word, can be downloaded
-              from: <a href="http://vgtc.org/publications/conference">http://vgtc.org/publications/conference</a>. The submission, however, must be made in PDF format. Authors can decide whether they want to reveal
+              from: <a href="https://tc.computer.org/vgtc/publications/journal/">https://tc.computer.org/vgtc/publications/journal/</a>. The submission, however, must be made in PDF format. Authors can decide whether they want to reveal
               their names on the submission (single-blind) or submit it anonymously (double-blind).
             </p>
 


### PR DESCRIPTION
VGTC moved the location of the TVCG templates, updating with a new link.